### PR TITLE
Fix: Remove https: dependency and use npm ci for deployments"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cmdk": "latest",
     "date-fns": "latest",
     "embla-carousel-react": "latest",
-    "https:": "latest",
+
     "input-otp": "latest",
     "lucide-react": "^0.454.0",
     "next": "14.2.16",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "devCommand": "next dev",
   "framework": "nextjs",
-  "installCommand": "rm -rf node_modules && npm cache clean --force && npm install --legacy-peer-deps",
+  "installCommand": "npm ci",
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "regions": ["iad1"],


### PR DESCRIPTION
     - Removes problematic "https:": "latest" dependency from package.json
     - Updates vercel.json to use "npm ci" for deterministic installs
     - Fixes deployment issues caused by invalid dependency

